### PR TITLE
Fix examples and descriptions

### DIFF
--- a/tutorials/toolhouse-for-tool-use-with-groq-api/Groq <> Toolhouse.ipynb
+++ b/tutorials/toolhouse-for-tool-use-with-groq-api/Groq <> Toolhouse.ipynb
@@ -13,7 +13,9 @@
    "id": "626a645c",
    "metadata": {},
    "source": [
-    "[Toolhouse](https://app.toolhouse.ai/) is the first marketplace of AI tools, featuring Code Interpreter, Web Search, and Email tools, among others. In this short demo, we'll show how to use Toolhouse with Groq API, in particular the Groq `llama3-groq-70b-8192-tool-use-preview` Large Language Model (LLM) that is fine-tuned for tool use, for effective and fast tool calling."
+    "[Toolhouse](https://app.toolhouse.ai/) is the first complete infrastructure for tool use. With Toolhouse, you can equip your LLM with tools like Code Interpreter, Web Search, and Email tools, among others. This equips your LLMs with the ability to search the web, send the emails they write, or run the code they generate, without the need for your to code or prompt these tools. These tools can be used across any LLM supported by Groq.\n",
+    "\n",
+    "In this short demo, we'll show how to help LLM generate precise answers to math problems. We'll use Toolhouse with the Groq API, in particular the Groq `llama3-groq-70b-8192-tool-use-preview` Large Language Model (LLM) that is fine-tuned for tool use, for effective and fast tool calling."
    ]
   },
   {
@@ -44,7 +46,8 @@
     "To integrate Groq and Toolhouse, you'll need to set up two environment variables: `GROQ_API_KEY` and `TOOLHOUSE_API_KEY`. Follow these steps to obtain your API keys:\n",
     "\n",
     "* **Groq API Key**: Create a free Groq API key by visiting the [Groq Console](https://console.groq.com/keys).\n",
-    "* **Toolhouse API Key**: Sign up for Toolhouse using [this link](https://join.toolhouse.ai) to receive $150 in credits. Then, navigate to the [Toolhouse API Keys page](https://app.toolhouse.ai/settings/api-keys) to generate your API key.\n",
+    "* **Toolhouse API Key**: Sign up for Toolhouse using [this link](https://join.toolhouse.ai) to receive $150 in credits. You will receive your API key as part of the onboarding step, and you can always, navigate to the [Toolhouse API Keys page](https://app.toolhouse.ai/settings/api-keys) to create and get an API key.\n",
+    "* **Install Code Interpreter**: In your [Toolhouse dashboard](https://app.toolhouse.ai), click Install next to Code Interpreter ([direct link](https://app.toolhouse.ai/store/code_interpreter)).\n",
     "\n",
     "Once you have both API keys, set them as environment variables to start using Groq and Toolhouse."
    ]
@@ -83,7 +86,7 @@
    "id": "89ad14fd",
    "metadata": {},
    "source": [
-    "We can use the `th.get_tools()` function to display all of the Toolhouse tools available:"
+    "If you like, you can use the `th.get_tools()` function to display all of the Toolhouse tools you have installed:"
    ]
   },
   {
@@ -154,10 +157,7 @@
     "messages = [\n",
     "  {\n",
     "    \"role\": \"user\",\n",
-    "    \"content\": \"\"\"Run this Python code: ```python\n",
-    "a = 409830948\n",
-    "print(a / 9834294824)\n",
-    "```\"\"\",\n",
+    "    \"content\": \"Generate and run code to solve this equation: x = 409830948 / 9834294824.\",\n",
     "  }\n",
     "]"
    ]
@@ -191,7 +191,7 @@
    "id": "f279224f",
    "metadata": {},
    "source": [
-    "As you can see, the LLM properly identified that we'd like to invoke the `code_interpretor` tool, and properly passed our code to it via the `code_str` parameter:"
+    "As you can see, the LLM properly identified that we'd like to invoke the `code_interpreter` tool, and properly passed our code to it via the `code_str` parameter:"
    ]
   },
   {


### PR DESCRIPTION
This PR provides the following changes, based on feedback from users who were not able to run the notebook:

- Fixes the text blocks to accurately describe Toolhouse and its tools
- Fixes a typo in the tool name
- Fixes the prompt to give the LLM the ability to generate its code as well as running it