### PR TITLE
docs: update deprecated model names in RAG benchmarking notebook

### DIFF
--- a/tutorials/04-rag/benchmarking-rag-langchain/benchmarking_rag.ipynb
+++ b/tutorials/04-rag/benchmarking-rag-langchain/benchmarking_rag.ipynb
@@ -115,9 +115,9 @@
     "from langchain_community.embeddings.huggingface import HuggingFaceEmbeddings\n",
     "\n",
     "embed_model = HuggingFaceEmbeddings(model_name=\"BAAI/bge-small-en-v1.5\")\n",
-    "rag_llm = ChatGroq(model=\"llama3-8b-8192\") # Used for RAG\n",
-    "qa_llm = ChatGroq(model=\"llama3-70b-8192\", temperature=0.1) # Used to create eval dataset\n",
-    "benchmark_llm = ChatGroq(model=\"llama3-70b-8192\") # Used to evaluate (Judge)"
+    "rag_llm = ChatGroq(model=\"llama-3.1-8b-instant\") # Used for RAG\n",
+    "qa_llm = ChatGroq(model=\"llama-3.3-70b-versatile\", temperature=0.1) # Used to create eval dataset\n",
+    "benchmark_llm = ChatGroq(model=\"llama-3.3-70b-versatile\") # Used to evaluate (Judge)"
    ]
   },
   {


### PR DESCRIPTION
Update deprecated llama3-8b-8192 and llama3-70b-8192 model names to llama-3.1-8b-instant and llama-3.3-70b-versatile respectively