### PR TITLE
docs: replace deprecated llama3-70b-8192 in MoA notebook

### DIFF
--- a/tutorials/07-agents/mixture-of-agents/mixture_of_agents.ipynb
+++ b/tutorials/07-agents/mixture-of-agents/mixture_of_agents.ipynb
@@ -202,7 +202,7 @@
     "\n",
     "MAIN_AGENT = create_agent(\n",
     "    system_prompt=\"You are a helpful assistant named Bob.\\n{helper_response}\",\n",
-    "    model_name=\"llama3-70b-8192\",\n",
+    "    model_name=\"llama-3.3-70b-versatile\",\n",
     "    temperature=0.1,\n",
     ")"
    ]


### PR DESCRIPTION
Updates the main agent model from llama3-70b-8192 to llama-3.3-70b-versatile to align the notebook with current Groq model recommendations and other models already used within the example.