### PR TITLE
feat: add Groq + TWZRD Agent Intel MCP tutorial

### DIFF
--- a/tutorials/03-mcp/mcp-twzrd/mcp-twzrd.ipynb
+++ b/tutorials/03-mcp/mcp-twzrd/mcp-twzrd.ipynb
@@ -1,0 +1,273 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Groq + TWZRD Agent Intel MCP: Web3 Agent Trust Verification\n",
+    "\n",
+    "This notebook shows Python developers how to connect Groq with the TWZRD Agent Intel MCP server\n",
+    "to verify Web3 AI agent trustworthiness before making x402 payments.\n",
+    "\n",
+    "[TWZRD Agent Intel](https://intel.twzrd.xyz) is a live production MCP server (streamable-http) that\n",
+    "scores any Solana wallet address on a 0\u2013100 trust scale using on-chain signals.\n",
+    "\n",
+    "We will do this in three simple steps:\n",
+    "1. Set up the **Groq client** for fast AI responses.\n",
+    "2. Set up the **TWZRD MCP server** for on-chain trust scoring.\n",
+    "3. **Connect them together** using the Responses API.\n",
+    "\n",
+    "---\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Getting Started\n",
+    "\n",
+    "Follow these steps to set up:\n",
+    "1. **Sign up** for Groq at [console.groq.com](https://console.groq.com/keys) to get your free API key.\n",
+    "2. **TWZRD requires no API key** \u2014 the `score_agent` and `preflight_check` tools are free.\n",
+    "3. **Paste your Groq API key** into the cell below and run the cell.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# To export your API keys into a .env file, run the following cell (replace with your actual key):\n",
+    "!echo \"GROQ_API_KEY=<your-groq-api-key>\" >> .env"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import json\n",
+    "import os\n",
+    "import time\n",
+    "\n",
+    "GROQ_API_KEY = os.getenv(\"GROQ_API_KEY\")\n",
+    "\n",
+    "if not GROQ_API_KEY:\n",
+    "    raise ValueError(\"GROQ_API_KEY environment variable not set\")\n",
+    "\n",
+    "print(\"GROQ_API_KEY:\", GROQ_API_KEY[:8] + \"...\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Step 1: Set up the Groq client\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Model configuration\n",
+    "MODEL = \"openai/gpt-oss-120b\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from openai import OpenAI\n",
+    "\n",
+    "# Set up Groq client using the OpenAI-compatible endpoint\n",
+    "client = OpenAI(base_url=\"https://api.groq.com/api/openai/v1\", api_key=GROQ_API_KEY)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Step 2: Set up TWZRD Agent Intel MCP server\n",
+    "\n",
+    "TWZRD Agent Intel exposes three tools via streamable-http at `https://intel.twzrd.xyz/mcp`:\n",
+    "\n",
+    "| Tool | Cost | Description |\n",
+    "|------|------|-------------|\n",
+    "| `score_agent` | Free | 0\u2013100 trust score + on-chain risk signals |\n",
+    "| `preflight_check` | Free | Quick go/no-go before x402 payment |\n",
+    "| `get_trust_receipt` | $0.01 USDC (x402) | Signed on-chain trust receipt |\n",
+    "\n",
+    "No API key required for the free tools.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Set up TWZRD Agent Intel MCP server\n",
+    "# No API key required \u2014 free tools are public\n",
+    "tools = [\n",
+    "    {\n",
+    "        \"type\": \"mcp\",\n",
+    "        \"server_url\": \"https://intel.twzrd.xyz/mcp\",\n",
+    "        \"server_label\": \"twzrd\",\n",
+    "        \"require_approval\": \"never\",\n",
+    "    }\n",
+    "]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Step 3: Connect Groq to TWZRD MCP through Groq's Responses API\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def check_agent_trust(client, tools, wallet: str, question: str):\n",
+    "    \"\"\"Connect Groq to TWZRD for Web3 agent trust verification.\"\"\"\n",
+    "\n",
+    "    start_time = time.time()\n",
+    "\n",
+    "    response = client.responses.create(\n",
+    "        model=MODEL,\n",
+    "        input=question,\n",
+    "        tools=tools,\n",
+    "        stream=False,\n",
+    "        temperature=0.1,\n",
+    "        top_p=0.4,\n",
+    "    )\n",
+    "\n",
+    "    total_time = time.time() - start_time\n",
+    "\n",
+    "    # Extract output text\n",
+    "    output_text = \"\"\n",
+    "    mcp_calls = {\"mcp_calls_performed\": []}\n",
+    "\n",
+    "    for item in response.output:\n",
+    "        if hasattr(item, \"type\"):\n",
+    "            if item.type == \"message\":\n",
+    "                for content in item.content:\n",
+    "                    if hasattr(content, \"text\"):\n",
+    "                        output_text = content.text\n",
+    "            elif item.type == \"mcp_call\":\n",
+    "                mcp_calls[\"mcp_calls_performed\"].append(\n",
+    "                    {\n",
+    "                        \"type\": item.type,\n",
+    "                        \"name\": getattr(item, \"name\", \"unknown\"),\n",
+    "                        \"server_label\": getattr(item, \"server_label\", \"twzrd\"),\n",
+    "                        \"arguments\": getattr(item, \"arguments\", \"{}\"),\n",
+    "                        \"output\": getattr(item, \"output\", \"\"),\n",
+    "                    }\n",
+    "                )\n",
+    "\n",
+    "    print(f\"\\nTime taken: {total_time:.2f} seconds\")\n",
+    "    print(f\"\\nModel response:\\n{output_text}\")\n",
+    "\n",
+    "    return {\n",
+    "        \"output\": output_text,\n",
+    "        \"mcp_calls\": mcp_calls,\n",
+    "        \"time\": total_time,\n",
+    "    }"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Demo 1: Trust score for a known Web3 agent\n",
+    "\n",
+    "We check the trust score of `D1QkbFJKiPsymJ65RKHhF6DFB8sPMfpBaFBzuHKfJGWi` \u2014 a known\n",
+    "repeat x402 payer from the Dexter ecosystem with 48+ paid transactions.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "WALLET = \"D1QkbFJKiPsymJ65RKHhF6DFB8sPMfpBaFBzuHKfJGWi\"\n",
+    "\n",
+    "trust_check = check_agent_trust(\n",
+    "    client,\n",
+    "    tools,\n",
+    "    WALLET,\n",
+    "    f\"Check the trust score for Solana wallet {WALLET} and tell me whether it's safe to make an x402 payment to this agent. Use both score_agent and preflight_check.\",\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Demo 2: Try it yourself\n",
+    "\n",
+    "Replace the wallet address with any Solana wallet you want to check:\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Replace with any Solana wallet address\n",
+    "MY_WALLET = \"<your-solana-wallet-address>\"\n",
+    "\n",
+    "custom_check = check_agent_trust(\n",
+    "    client,\n",
+    "    tools,\n",
+    "    MY_WALLET,\n",
+    "    f\"What is the trust score for Solana wallet {MY_WALLET}? Is it safe for an autonomous agent to pay this wallet via x402?\",\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Summary\n",
+    "\n",
+    "You've just connected Groq's fast inference to TWZRD Agent Intel's on-chain trust scoring.\n",
+    "\n",
+    "| What you used | Why |\n",
+    "|--------------|-----|\n",
+    "| **Groq Responses API** | Fast inference with built-in MCP tool execution |\n",
+    "| **TWZRD MCP server** | Live on-chain trust data for any Solana wallet |\n",
+    "| **`score_agent` tool** | 0\u2013100 trust score + risk signals |\n",
+    "| **`preflight_check` tool** | Go/no-go decision before payment |\n",
+    "\n",
+    "**Next steps**: Use `get_trust_receipt` for signed on-chain receipts (x402 paid, $0.01 USDC).\n",
+    "\n",
+    "Docs: [intel.twzrd.xyz](https://intel.twzrd.xyz) | PyPI: `pip install twzrd-agent-intel`\n"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.10.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
## Summary

Adds `tutorials/03-mcp/mcp-twzrd/mcp-twzrd.ipynb` — a tutorial showing how to connect Groq with the [TWZRD Agent Intel MCP server](https://intel.twzrd.xyz) to verify Web3 AI agent trustworthiness before making x402 payments.

TWZRD follows the same pattern as the existing MCP tutorials (`mcp-exa`, `mcp-tavily`): a hosted MCP server accessed via `server_url` in Groq's Responses API tools array.

## What the tutorial covers

1. Set up Groq client (OpenAI-compatible endpoint)
2. Configure TWZRD MCP server (no API key required for free tools)
3. Call `score_agent` and `preflight_check` via Groq's `responses.create()`

**TWZRD tools:**
- `score_agent(wallet)` — 0–100 trust score + on-chain risk signals (free)
- `preflight_check(wallet)` — go/no-go before x402 payment (free)
- `get_trust_receipt(wallet)` — signed on-chain receipt (x402 paid, $0.01 USDC)

**Server URL:** `https://intel.twzrd.xyz/mcp` (streamable-http, live production)

## How to run

```
pip install openai
export GROQ_API_KEY=<your-key>
jupyter notebook tutorials/03-mcp/mcp-twzrd/mcp-twzrd.ipynb
```

No TWZRD API key needed — the two free tools are public.

## Evaluation against cookbook criteria

| Criteria | Notes |
|----------|-------|
| Useful | x402 agent payments are an emerging use case; trust scoring is a practical prerequisite |
| Original | First Solana/Web3 trust verification MCP in the cookbook |
| Clear | Follows the identical 3-step structure as mcp-exa and mcp-tavily |
| Accurate | Tested against live endpoint; free tools return JSON trust data |
| Depth | Shows both tools (`score_agent` + `preflight_check`) with real wallet addresses |
| Grammar | Reviewed ✓ |