### PR TITLE
fix: correct hyperlink in audio chunking tutorial

### DIFF
--- a/tutorials/06-multimodal/audio-chunking/audio_chunking_tutorial.ipynb
+++ b/tutorials/06-multimodal/audio-chunking/audio_chunking_tutorial.ipynb
@@ -132,7 +132,7 @@
     "\n",
     "We highly recommend specifying `language`. Whisper analyzes the first 30 seconds of your audio to determine language, but this could result in errors from Whisper possibly choosing the wrong language, especially if your audio has background noise, music, or silence in that timeframe. Specifying `language` will also help speed up requests since Whisper can forego audio analysis for determining language.\n",
     "\n",
-    "**Tip:** Setting `response_format` to `verbose_json` for Groq API transcription and translation endpoints provides timestamps for audio segments! It also provides `avg_logprob`, `compression_ratio`, and `no_speech_prob`! See our [official docs](https://console.groq.com/docs/speech-text) for more info.\n",
+    "**Tip:** Setting `response_format` to `verbose_json` for Groq API transcription and translation endpoints provides timestamps for audio segments! It also provides `avg_logprob`, `compression_ratio`, and `no_speech_prob`! See our [official docs](https://console.groq.com/docs/speech-to-text) for more info.\n",
     "\n",
     "Once the single chunk is transcribed, the function returns a tuple of the transcription result and the processing time."
    ]


### PR DESCRIPTION
This PR updates an incorrect hyperlink in the audio chunking tutorial to point to the correct destination.