### PR TITLE
fix: replace decommissioned model IDs in quickstart and tool use tutorials

### DIFF
--- a/tutorials/01-quickstart/groq-quickstart-conversational-chatbot/main.py
+++ b/tutorials/01-quickstart/groq-quickstart-conversational-chatbot/main.py
@@ -25,7 +25,7 @@ while True:
   # Append the user input to the chat history
   chat_history.append({"role": "user", "content": user_input})
 
-  response = client.chat.completions.create(model="llama3-70b-8192",
+  response = client.chat.completions.create(model="llama-3.3-70b-versatile",
                                             messages=chat_history,
                                             max_tokens=100,
                                             temperature=1.2)

--- a/tutorials/02-tool-use/groqing-the-stock-market-function-calling-llama3/main.py
+++ b/tutorials/02-tool-use/groqing-the-stock-market-function-calling-llama3/main.py
@@ -124,7 +124,7 @@ def call_functions(llm_with_tools, user_prompt):
 
 
 
-llm = ChatGroq(groq_api_key = os.getenv('GROQ_API_KEY'),model = 'llama3-70b-8192')
+llm = ChatGroq(groq_api_key = os.getenv('GROQ_API_KEY'),model = 'llama-3.3-70b-versatile')
 
 tools = [get_stock_info, get_historical_price]
 llm_with_tools = llm.bind_tools(tools)

--- a/tutorials/02-tool-use/text-to-sql-json-mode/main.py
+++ b/tutorials/02-tool-use/text-to-sql-json-mode/main.py
@@ -91,7 +91,7 @@ def main():
     and initiates a conversation in the command line.
     """
 
-    model = "llama3-70b-8192"
+    model = "llama-3.3-70b-versatile"
 
     # Get the Groq API key and create a Groq client
     groq_api_key = os.getenv('GROQ_API_KEY')

--- a/tutorials/02-tool-use/verified-sql-function-calling/main.py
+++ b/tutorials/02-tool-use/verified-sql-function-calling/main.py
@@ -57,7 +57,7 @@ def execute_duckdb_query_function_calling(query_name,verified_queries_dict):
     return query_result
 
 
-model = "llama3-8b-8192"
+model = "llama-3.1-8b-instant"
 
 # Initialize the Groq client
 groq_api_key = os.getenv('GROQ_API_KEY')


### PR DESCRIPTION
## Problem

Quickstart + 3 tool use tutorials point at dead models. Run them today, no output, just `model_not_found`. Hits `01-quickstart/groq-quickstart-conversational-chatbot` too, first example new user try.

## Fix

| File | Before | After |
|---|---|---|
| `tutorials/01-quickstart/groq-quickstart-conversational-chatbot/main.py` | `llama3-70b-8192` | `llama-3.3-70b-versatile` |
| `tutorials/02-tool-use/groqing-the-stock-market-function-calling-llama3/main.py` | `llama3-70b-8192` | `llama-3.3-70b-versatile` |
| `tutorials/02-tool-use/text-to-sql-json-mode/main.py` | `llama3-70b-8192` | `llama-3.3-70b-versatile` |
| `tutorials/02-tool-use/verified-sql-function-calling/main.py` | `llama3-8b-8192` | `llama-3.1-8b-instant` |

## Why these models

Both old models shut down 08/30/25. Mapping comes straight from [deprecations docs](https://console.groq.com/docs/deprecations):

- `llama3-70b-8192` -> `llama-3.3-70b-versatile`
- `llama3-8b-8192` -> `llama-3.1-8b-instant`

Both replacements are current production models.

Bonus: kills drift between two tutorials for same app. Notebook `02-tool-use/llama3-stock-market-function-calling` already on `llama-3.3-70b-versatile`. Replit twin `02-tool-use/groqing-the-stock-market-function-calling-llama3` stuck on old ID. Now match.

## Checks

- Model IDs only. No prose, tutorial names, or directory names touched.
- Grepped `tutorials/01-quickstart/` and `tutorials/02-tool-use/`, zero dead IDs left.
- All 4 files still compile.
